### PR TITLE
Preserve images across rounds

### DIFF
--- a/server.go
+++ b/server.go
@@ -234,7 +234,16 @@ func (s *Server) handleNextGame(rw http.ResponseWriter, req *http.Request) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	g := newGame(request.GameID, s.imagePaths, randomState())
+	// Find the existing game so we can fetch the images it used.
+	g, exists := s.games[request.GameID]
+
+	if !exists {
+		http.Error(rw, "Invalid game", 404)
+		return
+	}
+
+	// Create a new game with the same ID and images from the past game but with a random state.
+	g = newGame(request.GameID, g.ImagePaths, randomState())
 	s.games[request.GameID] = g
 	writeGame(rw, g)
 }


### PR DESCRIPTION
Preserve images across rounds by looking up the previous game and copying it's images across.

This should probably be merged before #23, as this new code will also need `go fmt`ing.

Fixes #20.