### PR TITLE
Use window origin instead of window host for header link

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -25,7 +25,7 @@ window.App = React.createClass({
         return (
             <div id="application">
                 <div id="topbar">
-                    <a href={"https://" + window.location.host}>
+                    <a href={window.location.origin}>
                         <h1>Codenames Pictures</h1>
                     </a>
                 </div>


### PR DESCRIPTION
This change means we no longer need to prefix a protocol, as origin already includes it.

I noticed this when testing as I am not hosting the application over HTTPS, and it was taking me to a HTTPS URL when clicking the header.