### PR TITLE
Preserve original images between rounds

### DIFF
--- a/game.go
+++ b/game.go
@@ -98,9 +98,9 @@ type Game struct {
 	CreatedAt    time.Time `json:"created_at"`
 	StartingTeam Team      `json:"starting_team"`
 	WinningTeam  *Team     `json:"winning_team,omitempty"`
-	// Leaving the json as words makes it all easier.
-	ImagePaths []string `json:"words"`
-	Layout     []Team   `json:"layout"`
+	Images       []string  `json:"-"`
+	RoundImages  []string  `json:"words"`
+	Layout       []Team    `json:"layout"`
 }
 
 func (g *Game) checkWinningCondition() {
@@ -172,7 +172,8 @@ func newGame(id string, imagePaths []string, state GameState) *Game {
 		ID:           id,
 		CreatedAt:    time.Now(),
 		StartingTeam: Team(rnd.Intn(2)) + Red,
-		ImagePaths:   make([]string, 0, imagesPerGame),
+		Images:       imagePaths,
+		RoundImages:  make([]string, 0, imagesPerGame),
 		Layout:       make([]Team, 0, imagesPerGame),
 		GameState:    state,
 	}
@@ -183,7 +184,7 @@ func newGame(id string, imagePaths []string, state GameState) *Game {
 		w := imagePaths[rnd.Intn(len(imagePaths))]
 		if _, ok := used[w]; !ok {
 			used[w] = struct{}{}
-			game.ImagePaths = append(game.ImagePaths, w)
+			game.RoundImages = append(game.RoundImages, w)
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -250,8 +250,8 @@ func (s *Server) handleNextGame(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Create a new game with the same ID and images from the past game but with a random state.
-	g = newGame(request.GameID, g.ImagePaths, randomState())
+	// Create a new game with the same ID and source images from the past game but with a random state.
+	g = newGame(request.GameID, g.Images, randomState())
 	s.games[request.GameID] = g
 	writeGame(rw, g)
 }


### PR DESCRIPTION
This was supposed to be fixed in #25, but that fix actually retained the randomly chosen images between rounds as opposed to selecting a new set of random images from the source pool.

This PR changes the `Game` struct to now also store the original source images so it can pick a new set for each round. This source images aren't returned in the JSON as the frontend doesn't have any need for them.

Fixes #20.